### PR TITLE
Documentation/known issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,9 @@ COPY migrations /usr/src/app/migrations
 COPY examples /usr/src/app/examples
 COPY initapp.sh /usr/src/app/
 COPY *.py /usr/src/app/
+RUN mkdir -p /usr/src/app/log
 
-# dos2unix for initapp.sh
+# dos2unix for a friendly entrypoint script
 RUN dos2unix initapp.sh
 RUN chmod +x initapp.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt update -y && apt-get install -y --no-install-recommends \
 		git \
 		python3-dev \
 		libffi-dev \
-		libpq-dev
+		libpq-dev \
+		logrotate
 		
 # set work directory
 WORKDIR /usr/src/app

--- a/cornflow/gunicorn.py
+++ b/cornflow/gunicorn.py
@@ -16,4 +16,5 @@ timeout = 300
 keepalive = 300
 graceful_timeout = 300
 log_level = "info"
-log_file = "/usr/src/app/log/gunicorn.log"
+accesslog = "/usr/src/app/log/cornflow.log"
+errorlog = "/usr/src/app/log/server.log"

--- a/cornflow/gunicorn.py
+++ b/cornflow/gunicorn.py
@@ -16,3 +16,4 @@ timeout = 300
 keepalive = 300
 graceful_timeout = 300
 log_level = "info"
+log_file = "/usr/src/app/log/gunicorn.log"

--- a/cornflow/gunicorn.py
+++ b/cornflow/gunicorn.py
@@ -1,12 +1,11 @@
 """gunicorn WSGI server configuration."""
+import os
 from multiprocessing import cpu_count
-from os import environ
-
 
 def max_workers():
     return cpu_count()
 
-
+pidfile = "/usr/src/app/gunicorn.pid"
 chdir = "/usr/src/app"
 bind = "0.0.0.0:5000"
 max_requests = 1000
@@ -16,5 +15,7 @@ timeout = 300
 keepalive = 300
 graceful_timeout = 300
 log_level = "info"
-accesslog = "/usr/src/app/log/cornflow.log"
-errorlog = "/usr/src/app/log/server.log"
+
+if os.getenv("CORNFLOW_LOGGING") == "file":
+    accesslog = "/usr/src/app/log/info.log"
+    errorlog = "/usr/src/app/log/error.log"

--- a/docker-compose-airflow-celery-separate.yml
+++ b/docker-compose-airflow-celery-separate.yml
@@ -12,8 +12,8 @@ services:
     environment:
       - AIRFLOW_USER=admin
       - AIRFLOW_PWD=admin
-      - CORNFLOW_SERVICE_USER=serviceuser@cornflow.com
-      - CORNFLOW_SERVICE_PWD=servicecornflow1234
+      - CORNFLOW_SERVICE_USER=service_user@cornflow.com
+      - CORNFLOW_SERVICE_PWD=serviceuser1234
       - AIRFLOW_DB_HOST=airflow_db
       - AIRFLOW_DB_PORT=5432
       - AIRFLOW_DB_USER=airflow
@@ -46,8 +46,8 @@ services:
     environment:
       - AIRFLOW_USER=admin
       - AIRFLOW_PWD=admin
-      - CORNFLOW_SERVICE_USER=serviceuser@cornflow.com
-      - CORNFLOW_SERVICE_PWD=servicecornflow1234
+      - CORNFLOW_SERVICE_USER=service_user@cornflow.com
+      - CORNFLOW_SERVICE_PWD=serviceuser1234
       - AIRFLOW_DB_HOST=airflow_db
       - AIRFLOW_DB_PORT=5432
       - AIRFLOW_DB_USER=airflow

--- a/docker-compose-cornflow-celery.yml
+++ b/docker-compose-cornflow-celery.yml
@@ -9,8 +9,8 @@ services:
     ports:
       - 5000:5000
     environment:
-      - CORNFLOW_ADMIN_USER=user@cornflow.com
-      - CORNFLOW_ADMIN_PWD=admincornflow1234
+      - CORNFLOW_ADMIN_EMAIL=cornflow_admin@cornflow.com
+      - CORNFLOW_ADMIN_PWD=cornflowadmin1234
       - CORNFLOW_DB_HOST=cornflow_db
       - CORNFLOW_DB_PORT=5432
       - CORNFLOW_DB_USER=cornflow

--- a/docker-compose-cornflow-separate.yml
+++ b/docker-compose-cornflow-separate.yml
@@ -9,10 +9,10 @@ services:
     ports:
       - 5000:5000
     environment:
-      - CORNFLOW_ADMIN_USER=user@cornflow.com
-      - CORNFLOW_ADMIN_PWD=admincornflow1234
-      - CORNFLOW_SERVICE_USER=serviceuser@cornflow.com
-      - CORNFLOW_SERVICE_PWD=servicecornflow1234
+      - CORNFLOW_ADMIN_EMAIL=cornflow_admin@cornflow.com
+      - CORNFLOW_ADMIN_PWD=cornflowadmin1234
+      - CORNFLOW_SERVICE_USER=service_user@cornflow.com
+      - CORNFLOW_SERVICE_PWD=serviceuser1234
       - AIRFLOW_USER=admin
       - AIRFLOW_PWD=admin
       - CORNFLOW_DB_HOST=cornflow_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,10 @@ services:
     ports:
       - 5000:5000
     environment:
-      - CORNFLOW_ADMIN_USER=user@cornflow.com
-      - CORNFLOW_ADMIN_PWD=admincornflow1234
+      - CORNFLOW_ADMIN_EMAIL=cornflow_admin@cornflow.com
+      - CORNFLOW_ADMIN_PWD=cornflowadmin1234
+      - CORNFLOW_SERVICE_USER=service_user@cornflow.com
+      - CORNFLOW_SERVICE_PWD=serviceuser1234
       - CORNFLOW_DB_HOST=cornflow_db
       - CORNFLOW_DB_PORT=5432
       - CORNFLOW_DB_USER=cornflow
@@ -40,6 +42,8 @@ services:
     environment:
       - AIRFLOW_USER=admin
       - AIRFLOW_PWD=admin
+      - CORNFLOW_SERVICE_USER=service_user@cornflow.com
+      - CORNFLOW_SERVICE_PWD=serviceuser1234
       - AIRFLOW_DB_HOST=airflow_db
       - AIRFLOW_DB_PORT=5432
       - AIRFLOW_DB_USER=airflow

--- a/docs/source/deploy/access.rst
+++ b/docs/source/deploy/access.rst
@@ -146,7 +146,8 @@ Airflow ⇒ Cornflow
 Airflow use a cornflow service rights that allow it to do some operations. It´s used to get and post to any user’s instances and executions. In this way this role restrict for doing admin stuff (e.g., manage users or delete them)
 Service user is a good solution for doing all the data interaction between applications. You have only to pay attention to one account for set permissions and key values on deployment::
 
-    CORNFLOW_SERVICE_USER - service user account name for communications between cornflow and airflow (default value `serviceuser@cornflow.com`)
+    CORNFLOW_SERVICE_USER - service user account name for communications between cornflow and airflow (default value `service_user`)
+    CORNFLOW_SERVICE_MAIL - service user account email (default value `service_user@cornflow.com`)
     CORNFLOW_SERVICE_PWD - service user account password (default value `servicecornflow1234`)
 
 This connection is provided by::
@@ -160,8 +161,9 @@ Manage cornflow users
 
 In the cornflow image, if no environment variables are set, an admin user is created with these credentials::
 
-    name - user@cornflow.com
-    password - cornflow1234
+    CORNFLOW_ADMIN_USER - cornflow_admin
+    CORNFLOW_ADMIN_EMAIL - cornflow_admin@cornflow.com
+    CORNFLOW_ADMIN_PWD - cornflowadmin1234
 
 It is advisable to change the default admin user and keep the password in a safe place.
 
@@ -172,8 +174,8 @@ Manage airflow users
 
 The default administrator user for airflow and flower will be::
 
-    name - admin
-    password - admin
+    AIRFLOW_USER - admin
+    AIRFLOW_PWD - admin
 
 It is advisable to change the default admin user and keep the password in a safe place.
 `Access Control of Airflow Webserver UI <https://airflow.apache.org/docs/apache-airflow/stable/security/access-control.html>`_ is handled by Flask AppBuilder (FAB). Please read its related security document regarding its `security model <http://flask-appbuilder.readthedocs.io/en/latest/security.html>`_.

--- a/docs/source/deploy/logs.rst
+++ b/docs/source/deploy/logs.rst
@@ -5,9 +5,30 @@ Logging and monitoring
 Cornflow logs
 ****************
 
-At the moment cornflow does not have a log storage folder. All application logs are written to console output. In this way we can visualize them by launching the following command::
+Cornflow logs are written to console output (stdout) by default. In this way you can visualize them by launching the following command::
 
     docker logs `docker ps -q --filter ancestor=baobabsoluciones/cornflow`
+
+If you want to know about the possibilities offered by the docker log engine, you can visit the official documentation `here <https://docs.docker.com/engine/reference/commandline/logs/>`_.
+
+If you want to activate the persistent log storage in files, you must pass the value ``file`` to the environment variable ``CORNFLOW_LOGGING`` in the cornflow server deployment.
+Once the log storage is activated, these will be saved in the path ``/usr/src/app/log`` inside the cornflow container.
+To permanently store the logs even if the service is destroyed, you can mount a volume against the directory as follows::
+
+    --volume /local/path/to_storage/cornflow/logs:/usr/src/app/log
+
+The log files will rotate and be compressed following the configuration provided to the logrotate service::
+
+    number of files in directory - 30
+    frequency - daily
+    log file size - 20M
+
+Two files will be created in log directory::
+
+    info.log - record messages with access to the application with the default log level value ``info``
+    error.log - here the application errors will be recorded
+
+The compressed logs will have this format: ``info.log.1.gz``
 
 Airflow logs
 ****************

--- a/docs/source/deploy/problems.rst
+++ b/docs/source/deploy/problems.rst
@@ -36,6 +36,15 @@ Problem: Cornflow can´t reach postgres internal database
     
     Possible solution: See again the name given to CORNFLOW_DB_HOST environment variable in docker-compose file.
 
+Running cornflow
+^^^^^^^^^^^^^^^^^^^^^^
+
+Problem: Users were not created when cornflow started
+
+    Error: usage: manage.py [-?] {db,create_admin_user,create_service_user,access_init,register_base_assignations,register_actions,register_views,register_roles,update_views,clean_historic_data,shell,runserver} ...
+
+    Possible solution: If you have modified the entrypoint script, checks that the conditions are met in the execution of python mange.py create_admin_user/create_service_user.
+
 Flower 
 ^^^^^^^^^^
 

--- a/docs/source/deploy/problems.rst
+++ b/docs/source/deploy/problems.rst
@@ -1,4 +1,82 @@
 Known problems
 ------------------
 
-In progess.
+When deploying cornflow through docker, you may run into one of the following problems. It is difficult to cover all the possibilities but we will try to update the documentation to include at least those that happen to us.
+
+Situations
+*************
+
+Docker build
+^^^^^^^^^^^^^^^
+
+Problem: The volume airflow_config can´t be mounted.
+
+    Error: Unable to prepare context: path "local_path_to_docker-compose.yml/airflow_config"  
+    
+    Possible solution: Start docker-compose.yml from root path of cloned corn repository.
+
+Problem: The Dockerfile is not found by docker-compose. 
+    
+    Error: Not found or failed to solve with frontend dockerfile.v0: failed to read dockerfile 
+    
+    Possible solution: Start from the same path of Dockerfile or modify the location of it into the build section of docker-compose file.
+
+Problem: The image is not installing any linux pkg.
+    
+    Error: gcc exited code error 1 
+    
+    Possible solution: Try to use docker platform argument "—platform linux/amd64" for build image with extended compatibility.
+
+Cornflow database
+^^^^^^^^^^^^^^^^^^^^^^
+
+Problem: Cornflow can´t reach postgres internal database
+
+    Error: sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not translate host name "host_database" to address: Name or service not known 
+    
+    Possible solution: See again the name given to CORNFLOW_DB_HOST environment variable in docker-compose file.
+
+Flower 
+^^^^^^^^^^
+
+Problem: Can´t login to flower GUI
+
+    Error: Access denied
+    
+    Possible solution: The admin user and password is the same than airflow.
+
+Airflow
+^^^^^^^^^^^
+
+Problem: Can´t login to airflow GUI
+
+    Error: Bad Request The CSRF session token is missing
+
+    Possible solution: Delete cookies from web browser.
+
+Ldap docker
+^^^^^^^^^^^^^^^^
+
+Problem: Can´t login to flower GUI
+
+    Error: Access denied
+    
+    Possible solution: If airflow goes to ldap config, and you don´t give any values to AIRFLOW_USER and AIRFLOW_PWD, the default values are "admin/admin"
+
+Problem: Can´t login to airflow GUI
+
+    Error: Access denied
+
+    Possible solution: User is not same as normal deployment
+
+Problem: Openldap docker container don´t start
+
+    Error: Can´t parse ldif entry on line 1
+
+    Possible solution: Some entry on *.ldif file has not properly defined and slapd can´t start and populate the ldap server
+
+Problem: Openldap does not show entries from ldif file 
+
+    Error: failed: bash ls -l not ldif on path
+
+    Possible solution: Try to mount openldap volume with full local path of ldif folder in your machine

--- a/docs/source/deploy/production.rst
+++ b/docs/source/deploy/production.rst
@@ -71,10 +71,10 @@ In the `repository <https://raw.githubusercontent.com/baobabsoluciones/corn/mast
 
 With this docker template following users will be create in openldap server::
 
-    User ``administrator`` with password ``adminnistrator1234``
-    Service user ``cornflow`` with password ``cornflow1234``
-    Viewer user ``viewer`` with password ``viewer1234``
-    General user ``planner`` with password ``planner1234``
+    User "administrator" with password "adminnistrator1234"
+    Service user "cornflow" with password "cornflow1234"
+    Viewer user "viewer" with password "viewer1234"
+    General user "planner" with password "planner1234"
 
 Airflow does support this functionality and therefore it should be activated in the production deployment. To learn more about how to enable LDAP in airflow, see this `page <https://airflow.apache.org/docs/apache-airflow/1.10.1/security.html#ldap>`_.
 

--- a/initapp.sh
+++ b/initapp.sh
@@ -6,22 +6,27 @@
 : "${AIRFLOW_PWD:="admin"}"
 : "${AIRFLOW_URL:="http://webserver:8080"}"
 : "${CORNFLOW_URL:="http://cornflow:5000"}"
+: "${AUTH_TYPE:="1"}"
 : "${FLASK_APP:="cornflow.app"}"
 : "${FLASK_ENV:="development"}"
 : "${SECRET_KEY=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
 : "${DATABASE_URL=${CORNFLOW_DB_CONN}}"
-: "${CORNFLOW_ADMIN_USER:="user@cornflow.com"}"
-: "${CORNFLOW_ADMIN_PWD:="admincornflow1234"}"
-: "${CORNFLOW_SERVICE_USER:="serviceuser@cornflow.com"}"
-: "${CORNFLOW_SERVICE_PWD:="servicecornflow1234"}"
+: "${CORNFLOW_ADMIN_USER:="cornflow_admin"}"
+: "${CORNFLOW_ADMIN_EMAIL:="cornflow_admin@cornflow.com"}"
+: "${CORNFLOW_ADMIN_PWD:="cornflowadmin1234"}"
+: "${CORNFLOW_SERVICE_USER:="service_user"}"
+: "${CORNFLOW_SERVICE_EMAIL:="service_user@cornflow.com"}"
+: "${CORNFLOW_SERVICE_PWD:="serviceuser1234"}"
 
 export \
   AIRFLOW_USER \
   AIRFLOW_PWD \
   AIRFLOW_URL \
   CORNFLOW_ADMIN_USER \
+  CORNFLOW_ADMIN_EMAIL \
   CORNFLOW_ADMIN_PWD \
   CORNFLOW_SERVICE_USER \
+  CORNFLOW_SERVICE_EMAIL \
   CORNFLOW_SERVICE_PWD \
   CORNFLOW_DB_CONN \
   CORNFLOW_URL \
@@ -86,10 +91,13 @@ python manage.py db upgrade
 # make initdb access control
 python manage.py access_init
 
-# create cornflow admin user
-python manage.py create_admin_user --user="$CORNFLOW_ADMIN_USER" --password="$CORNFLOW_ADMIN_PWD"
-# create cornflow service user
-python manage.py create_service_user --user="$CORNFLOW_SERVICE_USER" --password="$CORNFLOW_SERVICE_PWD"
+# create user if auth type is db
+if [ "$AUTH_TYPE" = "1" ]; then
+  # create cornflow admin user
+  python manage.py create_admin_user --email="$CORNFLOW_ADMIN_EMAIL" --password="$CORNFLOW_ADMIN_PWD"
+  # create cornflow service user
+  python manage.py create_service_user --email="$CORNFLOW_SERVICE_EMAIL" --password="$CORNFLOW_SERVICE_PWD"
+fi
 
 # execute gunicorn with config file "gunicorn.py"
 /usr/local/bin/gunicorn -c cornflow/gunicorn.py "cornflow:create_app('$FLASK_ENV')"

--- a/initapp.sh
+++ b/initapp.sh
@@ -33,6 +33,7 @@ export \
   DATABASE_URL \
   FLASK_APP \
   FLASK_ENV \
+  CORNFLOW_LOGGING \
   SECRET_KEY \
   AUTH_TYPE \
   LDAP_PROTOCOL_VERSION \
@@ -84,6 +85,20 @@ if [ "$AUTH_TYPE" = "2" ]; then
     : "${LDAP_GROUP_TO_ROLE_VIEWER:="viewers"}"
     : "${LDAP_GROUP_TO_ROLE_PLANNER:="planners"}"
   >&2 printf '%s\n' "Cornflow will be deployed with LDAP Authorization. Please review your ldap auth configuration."
+fi
+
+if [ "$CORNFLOW_LOGGING" == "file" ]; then
+  cat > /etc/logrotate.d/cornflow <<EOF
+   /usr/src/app/log/*.log {
+          rotate 30
+          daily
+          compress
+          size 20M
+          postrotate
+              kill -HUP \$(cat /usr/src/app/gunicorn.pid)
+          endscript
+  }
+EOF
 fi
 
 # make initdb and/or migrations


### PR DESCRIPTION
Known problems and logging from cornflow app to files:

1. New content on docs/deploy/problems.rst section. This is going to be updated with known problems on deployment of cornflow server.
2. Gunicorn has now a .pid file to locate the process running in the server.
3. With new environment var (CORNFLOW_LOGGING=file) you can storage logs in /usr/src/app/log.
4. Install logrotate into cornflow docker image.
5. Logrotate configuration is written in initapp.sh script (frequency, rotation and compression).

Fixed cornflow user creation script call from initapp.sh 